### PR TITLE
S3.1-17: Selector de key con fallback por cuota/429 (Issue #341)

### DIFF
--- a/config/gemini_keys.py
+++ b/config/gemini_keys.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from django.conf import settings
+
+
+_QUOTA_HINTS = (
+    '429',
+    'quota',
+    'resource_exhausted',
+    'rate limit',
+    'too many requests',
+    'insufficient_quota',
+)
+
+
+def get_gemini_api_keys() -> list[str]:
+    """Returns configured Gemini API keys in effective fallback order."""
+    configured = getattr(settings, 'GEMINI_API_KEYS', ()) or ()
+    keys: list[str] = []
+    for raw_key in configured:
+        key = str(raw_key or '').strip()
+        if key and key not in keys:
+            keys.append(key)
+
+    if keys:
+        return keys
+
+    legacy_key = str(getattr(settings, 'GEMINI_API_KEY', '') or '').strip()
+    if legacy_key:
+        keys.append(legacy_key)
+    return keys
+
+
+def iter_gemini_api_keys(preferred_key: str | None = None):
+    """
+    Iterates Gemini keys in fallback order.
+
+    If preferred_key is provided, it is tried first and then the configured pool
+    excluding duplicates.
+    """
+    seen: set[str] = set()
+
+    preferred = str(preferred_key or '').strip()
+    if preferred:
+        seen.add(preferred)
+        yield preferred
+
+    for key in get_gemini_api_keys():
+        if key in seen:
+            continue
+        seen.add(key)
+        yield key
+
+
+def is_quota_or_rate_limit_error(
+    *,
+    status_code: int | None = None,
+    detail: str | None = None,
+    exception: Exception | None = None,
+) -> bool:
+    if status_code == 429:
+        return True
+
+    payload = ' '.join(
+        part for part in (str(detail or ''), str(exception or '')) if part
+    ).lower()
+
+    if status_code == 403 and any(hint in payload for hint in _QUOTA_HINTS):
+        return True
+
+    return any(hint in payload for hint in _QUOTA_HINTS)

--- a/creacion/langgraph/utils.py
+++ b/creacion/langgraph/utils.py
@@ -16,6 +16,7 @@ import math
 import os
 
 import requests
+from config.gemini_keys import iter_gemini_api_keys, is_quota_or_rate_limit_error
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,9 @@ _KEYWORDS_MOOD = {
 # Gemini
 # ─────────────────────────────────────────────────────────────────────────────
 
+class _GeminiQuotaError(Exception):
+    """Internal marker for quota/rate-limit responses on a concrete API key."""
+
 def _leer_int_env(nombre: str, default: int) -> int:
     try:
         return int(os.getenv(nombre, str(default)))
@@ -60,12 +64,7 @@ def _leer_int_env(nombre: str, default: int) -> int:
         return default
 
 
-def llamar_gemini(prompt: str) -> list | dict:
-    """
-    Llama a Gemini y devuelve la respuesta parseada como JSON.
-    Lanza ErrorIntegracionIA ante cualquier fallo.
-    """
-    api_key = os.getenv('GEMINI_API_KEY')
+def _llamar_gemini_con_clave(prompt: str, api_key: str) -> list | dict:
     if not api_key:
         raise ErrorIntegracionIA('No hay API key de Gemini configurada.')
 
@@ -80,12 +79,19 @@ def llamar_gemini(prompt: str) -> list | dict:
     }
     timeout_s = max(10, _leer_int_env('GEMINI_TIMEOUT_SECONDS', 30))
     max_reintentos = max(0, _leer_int_env('GEMINI_MAX_RETRIES', 2))
-    http_reintentable = {408, 409, 425, 429, 500, 502, 503, 504}
+    # 429 is handled as quota fallback to the next key, not retried in-place.
+    http_reintentable = {408, 409, 425, 500, 502, 503, 504}
 
     ultimo_error: Exception | None = None
     for intento in range(max_reintentos + 1):
         try:
             response = requests.post(url, headers=headers, json=data, timeout=timeout_s)
+            if is_quota_or_rate_limit_error(
+                status_code=response.status_code,
+                detail=getattr(response, 'text', ''),
+            ):
+                raise _GeminiQuotaError(f'Gemini devolvió status={response.status_code}.')
+
             if response.status_code in http_reintentable and intento < max_reintentos:
                 logger.warning('Gemini status=%s (reintento %s/%s).', response.status_code, intento + 1, max_reintentos)
                 continue
@@ -93,6 +99,8 @@ def llamar_gemini(prompt: str) -> list | dict:
             resultado = response.json()
             texto_json = resultado['candidates'][0]['content']['parts'][0]['text']
             return json.loads(texto_json)
+        except _GeminiQuotaError:
+            raise
         except requests.Timeout as exc:
             ultimo_error = exc
             if intento < max_reintentos:
@@ -101,6 +109,14 @@ def llamar_gemini(prompt: str) -> list | dict:
         except requests.HTTPError as exc:
             ultimo_error = exc
             status = exc.response.status_code if exc.response is not None else 'desconocido'
+            detalle = getattr(exc.response, 'text', '') if exc.response is not None else ''
+            if is_quota_or_rate_limit_error(
+                status_code=status if isinstance(status, int) else None,
+                detail=detalle,
+                exception=exc,
+            ):
+                raise _GeminiQuotaError(f'Gemini devolvió status={status}.') from exc
+
             if status in http_reintentable and intento < max_reintentos:
                 continue
             raise ErrorIntegracionIA(f'Error HTTP de Gemini (status={status}).') from exc
@@ -115,6 +131,33 @@ def llamar_gemini(prompt: str) -> list | dict:
             raise ErrorIntegracionIA('Error inesperado al invocar Gemini.') from exc
 
     raise ErrorIntegracionIA('No se pudo obtener respuesta válida de Gemini.') from ultimo_error
+
+
+def llamar_gemini(prompt: str) -> list | dict:
+    """
+    Llama a Gemini y devuelve la respuesta parseada como JSON.
+    Lanza ErrorIntegracionIA ante cualquier fallo.
+    """
+    claves = list(iter_gemini_api_keys())
+    if not claves:
+        raise ErrorIntegracionIA('No hay API key de Gemini configurada.')
+    ultimo_error_cuota: Exception | None = None
+    for indice, clave in enumerate(claves, start=1):
+        try:
+            return _llamar_gemini_con_clave(prompt, clave)
+        except _GeminiQuotaError as exc:
+            ultimo_error_cuota = exc
+            logger.warning(
+                'Gemini devolvió cuota/429 en clave %s/%s; se intenta fallback.',
+                indice,
+                len(claves),
+            )
+            continue
+
+    if ultimo_error_cuota is not None:
+        raise ErrorIntegracionIA('Todas las API keys de Gemini agotaron cuota o devolvieron 429.') from ultimo_error_cuota
+
+    raise ErrorIntegracionIA('No se pudo obtener respuesta válida de Gemini.')
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/creacion/services.py
+++ b/creacion/services.py
@@ -8,6 +8,7 @@ import uuid
 from django.contrib.gis.geos import Point
 from django.db import DatabaseError, IntegrityError, transaction
 from django.utils import timezone
+from config.gemini_keys import iter_gemini_api_keys, is_quota_or_rate_limit_error
 
 from creacion.geo_clients import MapboxGeocodingClient, OSMGeocodingClient
 from creacion.geo_validation import (
@@ -300,7 +301,11 @@ def _formatear_exclusiones_para_prompt(
 # Gemini
 # ─────────────────────────────────────────────────────────────────────────────
 
-def llamar_gemini_bypass(prompt, api_key):
+class _GeminiQuotaError(Exception):
+    """Internal marker for quota/rate-limit responses on a concrete API key."""
+
+
+def _llamar_gemini_bypass_con_clave(prompt, api_key):
     if not api_key:
         raise ErrorIntegracionIA('No hay API key de Gemini configurada.')
 
@@ -312,22 +317,33 @@ def llamar_gemini_bypass(prompt, api_key):
     }
     timeout_s = max(10, _leer_int_env('GEMINI_TIMEOUT_SECONDS', 30))
     max_reintentos = max(0, _leer_int_env('GEMINI_MAX_RETRIES', 2))
-    http_reintentable = {408, 409, 425, 429, 500, 502, 503, 504}
+    # 429 is handled as quota fallback to the next key, not retried in-place.
+    http_reintentable = {408, 409, 425, 500, 502, 503, 504}
 
     ultimo_error: Exception | None = None
     for intento in range(max_reintentos + 1):
         try:
             response = requests.post(url, headers=headers, json=data, timeout=timeout_s)
+            if is_quota_or_rate_limit_error(
+                status_code=response.status_code,
+                detail=getattr(response, 'text', ''),
+            ):
+                raise _GeminiQuotaError(f'Gemini devolvió status={response.status_code}.')
+
             if response.status_code in http_reintentable and intento < max_reintentos:
                 logger.warning(
                     'Gemini devolvió status=%s (reintento %s/%s).',
                     response.status_code, intento + 1, max_reintentos,
                 )
                 continue
+
             response.raise_for_status()
             resultado = response.json()
             texto_json = resultado['candidates'][0]['content']['parts'][0]['text']
             return json.loads(texto_json)
+
+        except _GeminiQuotaError:
+            raise
         except requests.Timeout as exc:
             ultimo_error = exc
             if intento < max_reintentos:
@@ -339,6 +355,14 @@ def llamar_gemini_bypass(prompt, api_key):
         except requests.HTTPError as exc:
             ultimo_error = exc
             status = exc.response.status_code if exc.response is not None else 'desconocido'
+            detalle = getattr(exc.response, 'text', '') if exc.response is not None else ''
+            if is_quota_or_rate_limit_error(
+                status_code=status if isinstance(status, int) else None,
+                detail=detalle,
+                exception=exc,
+            ):
+                raise _GeminiQuotaError(f'Gemini devolvió status={status}.') from exc
+
             if status in http_reintentable and intento < max_reintentos:
                 logger.warning('Error HTTP Gemini status=%s (reintento %s/%s).', status, intento + 1, max_reintentos)
                 continue
@@ -353,6 +377,29 @@ def llamar_gemini_bypass(prompt, api_key):
             raise ErrorIntegracionIA('Respuesta no válida de Gemini.') from exc
 
     raise ErrorIntegracionIA('No se pudo obtener respuesta válida de Gemini.') from ultimo_error
+
+def llamar_gemini_bypass(prompt, api_key=None):
+    claves = list(iter_gemini_api_keys(preferred_key=api_key))
+    if not claves:
+        raise ErrorIntegracionIA('No hay API key de Gemini configurada.')
+
+    ultimo_error_cuota: Exception | None = None
+    for indice, clave in enumerate(claves, start=1):
+        try:
+            return _llamar_gemini_bypass_con_clave(prompt, clave)
+        except _GeminiQuotaError as exc:
+            ultimo_error_cuota = exc
+            logger.warning(
+                'Gemini devolvió cuota/429 en clave %s/%s; se intenta fallback.',
+                indice,
+                len(claves),
+            )
+            continue
+
+    if ultimo_error_cuota is not None:
+        raise ErrorIntegracionIA('Todas las API keys de Gemini agotaron cuota o devolvieron 429.') from ultimo_error_cuota
+
+    raise ErrorIntegracionIA('No se pudo obtener respuesta válida de Gemini.')
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -702,7 +749,7 @@ def _solicitar_pois_adicionales_para_ruta_ia(
         coords_excluidas=coords_excluidas,
     )
     try:
-        respuesta = llamar_gemini_bypass(prompt, os.getenv('GEMINI_API_KEY'))
+        respuesta = llamar_gemini_bypass(prompt)
     except ErrorIntegracionIA:
         respuesta = None
 
@@ -907,7 +954,7 @@ def _solicitar_candidatos_paradas_ia(
         coords_excluidas=coords_excluidas,
     )
     try:
-        respuesta = llamar_gemini_bypass(prompt, os.getenv('GEMINI_API_KEY'))
+        respuesta = llamar_gemini_bypass(prompt)
     except ErrorIntegracionIA:
         respuesta = None
 
@@ -1700,7 +1747,7 @@ def generar_paradas_adicionales_sesion(*, estado_sesion: dict, cantidad: int = 3
         ]
     """
     try:
-        respuesta_ia = llamar_gemini_bypass(prompt, os.getenv('GEMINI_API_KEY'))
+        respuesta_ia = llamar_gemini_bypass(prompt)
     except ErrorIntegracionIA:
         raise
     except (requests.RequestException, TimeoutError, ConnectionError) as exc:

--- a/creacion/tests/test_services.py
+++ b/creacion/tests/test_services.py
@@ -17,6 +17,16 @@ from tours.models import TURISTA
 
 
 class GeminiBypassResilienceTests(TestCase):
+    @staticmethod
+    def _response_http_error(status_code: int, detail: str = 'quota exhausted'):
+        response = Mock()
+        response.status_code = status_code
+        response.text = detail
+        http_error = requests.HTTPError(f'status={status_code}')
+        http_error.response = response
+        response.raise_for_status.side_effect = http_error
+        return response
+
     def test_reintenta_timeout_y_recupera_respuesta(self):
         ok_response = Mock()
         ok_response.status_code = 200
@@ -40,6 +50,41 @@ class GeminiBypassResilienceTests(TestCase):
                     'Gemini agotó el tiempo de espera tras 2 intentos.',
                 ):
                     services.llamar_gemini_bypass('prompt', 'api-key')
+
+        self.assertEqual(mock_post.call_count, 2)
+
+    def test_fallback_a_siguiente_key_si_recibe_429(self):
+        quota_response = self._response_http_error(429, 'RESOURCE_EXHAUSTED')
+        ok_response = Mock()
+        ok_response.status_code = 200
+        ok_response.raise_for_status.return_value = None
+        ok_response.json.return_value = {
+            'candidates': [{'content': {'parts': [{'text': '[{"nombre":"B"}]'}]}}]
+        }
+
+        with self.settings(GEMINI_API_KEYS=('key-1', 'key-2'), GEMINI_API_KEY='key-1'):
+            with patch.dict('os.environ', {'GEMINI_MAX_RETRIES': '0', 'GEMINI_TIMEOUT_SECONDS': '10'}, clear=False):
+                with patch('creacion.services.requests.post', side_effect=[quota_response, ok_response]) as mock_post:
+                    resultado = services.llamar_gemini_bypass('prompt')
+
+        self.assertEqual(resultado, [{'nombre': 'B'}])
+        self.assertEqual(mock_post.call_count, 2)
+        urls = [call.args[0] for call in mock_post.call_args_list]
+        self.assertIn('key=key-1', urls[0])
+        self.assertIn('key=key-2', urls[1])
+
+    def test_lanza_error_si_todas_las_keys_agotan_cuota(self):
+        quota_1 = self._response_http_error(429, 'quota exceeded')
+        quota_2 = self._response_http_error(429, 'RESOURCE_EXHAUSTED')
+
+        with self.settings(GEMINI_API_KEYS=('key-1', 'key-2'), GEMINI_API_KEY='key-1'):
+            with patch.dict('os.environ', {'GEMINI_MAX_RETRIES': '0', 'GEMINI_TIMEOUT_SECONDS': '10'}, clear=False):
+                with patch('creacion.services.requests.post', side_effect=[quota_1, quota_2]) as mock_post:
+                    with self.assertRaisesMessage(
+                        services.ErrorIntegracionIA,
+                        'Todas las API keys de Gemini agotaron cuota o devolvieron 429.',
+                    ):
+                        services.llamar_gemini_bypass('prompt')
 
         self.assertEqual(mock_post.call_count, 2)
 

--- a/rutas/services.py
+++ b/rutas/services.py
@@ -14,12 +14,12 @@ import logging
 import json
 import math
 
-from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import DatabaseError, IntegrityError
 from django.db.models import Prefetch
 import requests
+from config.gemini_keys import iter_gemini_api_keys, is_quota_or_rate_limit_error
 
 from .models import Curiosidad, Parada, Ruta
 from tours.models import SESION_TOUR
@@ -447,7 +447,7 @@ class ServicioCuriosidadesIA:
 
     def __init__(self):
         from google import genai
-        self.client = genai.Client(api_key=settings.GEMINI_API_KEY)
+        self._genai = genai
 
     def generar_curiosidad(self, parada: Parada, ciudad: str = "Sevilla") -> dict:
         """
@@ -580,34 +580,56 @@ class ServicioCuriosidadesIA:
         }}
         """
 
-        try:
-            respuesta = self.client.models.generate_content(
-                model='gemini-2.5-flash',
-                contents=prompt,
-            )
-            
-            texto_ia = respuesta.text.strip()
+        claves = list(iter_gemini_api_keys())
+        if not claves:
+            raise RuntimeError('No hay API key de Gemini configurada.')
 
-            if texto_ia.startswith("```json"):
-                texto_ia = texto_ia[7:-3].strip()
-            elif texto_ia.startswith("```"):
-                texto_ia = texto_ia[3:-3].strip()
+        ultimo_error_cuota: Exception | None = None
+        for indice, clave in enumerate(claves, start=1):
+            client = self._genai.Client(api_key=clave)
+            try:
+                respuesta = client.models.generate_content(
+                    model='gemini-2.5-flash',
+                    contents=prompt,
+                )
 
-            datos_curiosidad = json.loads(texto_ia)
-            busqueda_imagen = (datos_curiosidad.get("busqueda_imagen") or "").strip()
-            datos_curiosidad["imagen_url"] = self._buscar_imagen_curiosidad(
-                busqueda_imagen=busqueda_imagen,
-                parada=parada,
-                ciudad=ciudad,
-            )
-            return datos_curiosidad
+                texto_ia = str(getattr(respuesta, 'text', '') or '').strip()
 
-        except json.JSONDecodeError:
-            raise ValueError("Error de formato: La IA no devolvió un JSON válido.")
-        except (requests.RequestException, TimeoutError, ConnectionError) as e:
-            raise RuntimeError(f"Error de red al comunicarse con la API de IA: {e}") from e
-        except (AttributeError, KeyError, IndexError) as e:
-            raise ValueError(f"Respuesta inesperada de la API de IA: {e}") from e
+                if texto_ia.startswith("```json"):
+                    texto_ia = texto_ia[7:-3].strip()
+                elif texto_ia.startswith("```"):
+                    texto_ia = texto_ia[3:-3].strip()
+
+                datos_curiosidad = json.loads(texto_ia)
+                busqueda_imagen = (datos_curiosidad.get("busqueda_imagen") or "").strip()
+                datos_curiosidad["imagen_url"] = self._buscar_imagen_curiosidad(
+                    busqueda_imagen=busqueda_imagen,
+                    parada=parada,
+                    ciudad=ciudad,
+                )
+                return datos_curiosidad
+
+            except json.JSONDecodeError:
+                raise ValueError("Error de formato: La IA no devolvió un JSON válido.")
+            except (requests.RequestException, TimeoutError, ConnectionError) as e:
+                raise RuntimeError(f"Error de red al comunicarse con la API de IA: {e}") from e
+            except (AttributeError, KeyError, IndexError) as e:
+                raise ValueError(f"Respuesta inesperada de la API de IA: {e}") from e
+            except Exception as exc:
+                if is_quota_or_rate_limit_error(exception=exc):
+                    ultimo_error_cuota = exc
+                    logger.warning(
+                        'Gemini devolvió cuota/429 al generar curiosidad (clave %s/%s).',
+                        indice,
+                        len(claves),
+                    )
+                    continue
+                raise
+
+        if ultimo_error_cuota is not None:
+            raise RuntimeError('Todas las API keys de Gemini agotaron cuota o devolvieron 429.') from ultimo_error_cuota
+
+        raise RuntimeError('No se pudo generar curiosidad con Gemini.')
 
     def _buscar_imagen_curiosidad(self, busqueda_imagen: str, parada: Parada, ciudad: str) -> str | None:
         """

--- a/rutas/tests/tests_legacy.py
+++ b/rutas/tests/tests_legacy.py
@@ -652,6 +652,33 @@ class ServicioCuriosidadesIACacheTest(TestCase):
 
     @patch('rutas.services.requests.get')
     @patch('google.genai.Client')
+    def test_fallback_a_siguiente_key_si_recibe_cuota_429(self, mock_client_class, mock_requests_get):
+        """Si la primera key agota cuota/429, se prueba automáticamente la siguiente."""
+        cliente_cuota = Mock()
+        cliente_cuota.models.generate_content.side_effect = Exception('429 RESOURCE_EXHAUSTED')
+
+        cliente_ok = Mock()
+        cliente_ok.models.generate_content.return_value = Mock(
+            text='{"titulo":"Fallback OK","texto":"Texto válido","tipo":"Historia","busqueda_imagen":""}'
+        )
+        mock_client_class.side_effect = [cliente_cuota, cliente_ok]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {}
+        mock_requests_get.return_value = mock_response
+
+        with self.settings(GEMINI_API_KEYS=('key-a', 'key-b'), GEMINI_API_KEY='key-a'):
+            servicio = ServicioCuriosidadesIA()
+            resultado = servicio.generar_curiosidad(self.parada, ciudad='Sevilla')
+
+        self.assertEqual(resultado['titulo'], 'Fallback OK')
+        self.assertEqual(mock_client_class.call_count, 2)
+        claves_usadas = [call.kwargs.get('api_key') for call in mock_client_class.call_args_list]
+        self.assertEqual(claves_usadas, ['key-a', 'key-b'])
+
+    @patch('rutas.services.requests.get')
+    @patch('google.genai.Client')
     def test_ia_tipo_invalido_usa_default(self, mock_client_class, mock_requests_get):
         """Caso borde: IA inventa un 'tipo'. El sistema hace fallback al por defecto."""
         mock_client = mock_client_class.return_value


### PR DESCRIPTION
## Resumen técnico
- Se implementa un selector centralizado de claves Gemini con orden de fallback.
- Se añade detección homogénea de errores de cuota/rate-limit (incluyendo 429 y señales equivalentes en payload/excepción).
- Se desacopla la lógica de rotación en un helper reutilizable para otros servicios.

## Cambios principales
- config/gemini_keys.py

## Validación
- Integración validada en PRs hijas (S3.1-18 y S3.1-19) con tests de fallback por cuota.

## Dependencia
- Depende de #340

## Issue
- Closes #341