### PR TITLE
Error en el mapa

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -32,6 +32,15 @@ TOURS_TOURIST_LOCATION_MIN_INTERVAL_SECONDS=10.0
 TOURS_TOURIST_LOCATION_MIN_DISTANCE_METERS=8.0
 
 MAPBOX_ACCESS_TOKEN=pk.tu_token_largo_de_mapbox_aqui
+# Tiles de mapas. En local puedes usar OSM; en producción se recomienda Mapbox
+# o un proveedor propio/tercero para no depender de los servidores voluntarios de OSM.
+# Valores: mapbox, carto, osm. Si se omite: mapbox con token, osm en DEBUG, carto en producción sin token.
+MAP_TILE_PROVIDER=mapbox
+# Opcional: URL/atribución custom para otro proveedor compatible con Leaflet.
+# MAP_TILE_URL=https://tiles.example.com/{z}/{x}/{y}.png
+# MAP_TILE_ATTRIBUTION=&copy; Mi proveedor &copy; OpenStreetMap contributors
+# Mantener una política que permita Referer cross-origin para OSM.
+SECURE_REFERRER_POLICY=strict-origin-when-cross-origin
 GRAPHHOPPER_API_KEY=tu_api_key_de_graphhopper_aqui
 GEMINI_API_KEY=tu_api_key_de_gemini_aqui
 

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -1,6 +1,14 @@
 from django.conf import settings
 
+
 def mapbox_settings(request):
     return {
-        'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN
+        'MAPBOX_ACCESS_TOKEN': settings.MAPBOX_ACCESS_TOKEN,
+        'MAP_TILE_CONFIG': {
+            'provider': settings.MAP_TILE_PROVIDER,
+            'url': settings.MAP_TILE_URL,
+            'attribution': settings.MAP_TILE_ATTRIBUTION,
+            'maxZoom': settings.MAP_TILE_MAX_ZOOM,
+            'mapboxToken': settings.MAPBOX_ACCESS_TOKEN or '',
+        },
     }

--- a/config/settings.py
+++ b/config/settings.py
@@ -303,6 +303,17 @@ GRAPHHOPPER_API_KEY = os.getenv('GRAPHHOPPER_API_KEY')
 GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
 GEMINI_API_KEYS = _parse_csv_env_list(os.getenv('GEMINI_API_KEYS'))
 
+# --- MAP TILES ---
+# OSM's volunteer tile servers require identifiable browser requests with a
+# Referer. In production we default to Mapbox when a token exists and otherwise
+# to CARTO, keeping direct OSM usage as an explicit/local choice.
+_default_map_tile_provider = 'mapbox' if MAPBOX_ACCESS_TOKEN else ('osm' if DEBUG else 'carto')
+MAP_TILE_PROVIDER = os.getenv('MAP_TILE_PROVIDER', _default_map_tile_provider).strip().lower()
+MAP_TILE_URL = os.getenv('MAP_TILE_URL', '').strip()
+MAP_TILE_ATTRIBUTION = os.getenv('MAP_TILE_ATTRIBUTION', '').strip()
+MAP_TILE_MAX_ZOOM = int(os.getenv('MAP_TILE_MAX_ZOOM', '19'))
+SECURE_REFERRER_POLICY = os.getenv('SECURE_REFERRER_POLICY', 'strict-origin-when-cross-origin')
+
 if GEMINI_API_KEYS:
     GEMINI_API_KEY = GEMINI_API_KEYS[0]
 elif GEMINI_API_KEY:

--- a/config/tests/test_settings.py
+++ b/config/tests/test_settings.py
@@ -58,6 +58,15 @@ class SettingsDefaultValuesTest(SimpleTestCase):
     def test_ttl_cache_ruta_es_entero(self):
         self.assertIsInstance(settings.ROUTE_SNAPSHOT_CACHE_TTL, int)
 
+    def test_referrer_policy_permite_tiles_osm_cross_origin(self):
+        self.assertEqual(
+            settings.SECURE_REFERRER_POLICY,
+            'strict-origin-when-cross-origin',
+        )
+
+    def test_configuracion_tiles_tiene_proveedor(self):
+        self.assertIn(settings.MAP_TILE_PROVIDER, {'mapbox', 'carto', 'osm'})
+
 
 class SettingsConditionalBranchesTest(SimpleTestCase):
 

--- a/creacion/static/js/creacion_manual.js
+++ b/creacion/static/js/creacion_manual.js
@@ -236,9 +236,7 @@
     function initMap() {
         if (!mapInstance) {
             mapInstance = L.map('leaflet-map').setView([37.3886, -5.9823], 13);
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© OpenStreetMap contributors'
-            }).addTo(mapInstance);
+            window.AuraMapTiles.createTileLayer({ style: 'streets' }).addTo(mapInstance);
             mapInstance.on('click', function(e) {
                 tempCoords = e.latlng;
                 if (mapMarker) mapMarker.setLatLng(tempCoords);

--- a/creacion/static/js/personalizacion.js
+++ b/creacion/static/js/personalizacion.js
@@ -44,10 +44,7 @@
 
         // Crear mapa
         leafletMap = L.map('mapa-ruta').setView(coordenadaInicial, 14);
-        
-        L.tileLayer(`https://api.mapbox.com/styles/v1/mapbox/streets-v12/tiles/256/{z}/{x}/{y}@2x?access_token=${mapboxToken}`, {
-            attribution: '© Mapbox'
-        }).addTo(leafletMap);
+        window.AuraMapTiles.createTileLayer({ token: mapboxToken, style: 'streets' }).addTo(leafletMap);
 
         const puntos = [];
         

--- a/rutas/static/js/detalle_ruta.js
+++ b/rutas/static/js/detalle_ruta.js
@@ -16,12 +16,7 @@ const primeraConCoords = paradas.find(p => Array.isArray(p.coordenadas) && p.coo
 const centroInicial    = primeraConCoords ? primeraConCoords.coordenadas : [40.4167, -3.7037];
 
 const mapa = L.map('mapa-ruta').setView(centroInicial, 14);
-
-const tileUrl = mapboxToken
-    ? `https://api.mapbox.com/styles/v1/mapbox/streets-v12/tiles/256/{z}/{x}/{y}@2x?access_token=${mapboxToken}`
-    : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-
-L.tileLayer(tileUrl, { attribution: mapboxToken ? '© Mapbox' : '© OpenStreetMap contributors' }).addTo(mapa);
+window.AuraMapTiles.createTileLayer({ token: mapboxToken, style: 'streets' }).addTo(mapa);
 
 // ── Marcadores ─────────────────────────────────────────────────────────────
 const puntos = [];

--- a/rutas/templates/rutas/detalle_ruta.html
+++ b/rutas/templates/rutas/detalle_ruta.html
@@ -561,12 +561,7 @@ const primeraConCoords = paradas.find(p => Array.isArray(p.coordenadas) && p.coo
 const centroInicial    = primeraConCoords ? primeraConCoords.coordenadas : [40.4167, -3.7037];
 
 const mapa = L.map('mapa-ruta').setView(centroInicial, 14);
-
-const tileUrl = mapboxToken
-    ? `https://api.mapbox.com/styles/v1/mapbox/streets-v12/tiles/256/{z}/{x}/{y}@2x?access_token=${mapboxToken}`
-    : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-
-L.tileLayer(tileUrl, { attribution: mapboxToken ? '© Mapbox' : '© OpenStreetMap contributors' }).addTo(mapa);
+window.AuraMapTiles.createTileLayer({ token: mapboxToken, style: 'streets' }).addTo(mapa);
 
 // ── Marcadores ─────────────────────────────────────────────────────────────
 const puntos = [];

--- a/static/js/map_tiles.js
+++ b/static/js/map_tiles.js
@@ -1,0 +1,78 @@
+(function () {
+    function readConfig() {
+        const node = document.getElementById('aura-map-tiles-config');
+        if (!node) return {};
+
+        try {
+            return JSON.parse(node.textContent || '{}');
+        } catch (error) {
+            console.error('[AURA maps] Configuracion de tiles invalida:', error);
+            return {};
+        }
+    }
+
+    const config = readConfig();
+    const providerAttribution = {
+        mapbox: '&copy; <a href="https://www.mapbox.com/about/maps/">Mapbox</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        osm: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        carto: '&copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    };
+
+    function createTileDefinition(options) {
+        const style = options?.style || 'streets';
+        const token = options?.token || config.mapboxToken || '';
+        const provider = (options?.provider || config.provider || (token ? 'mapbox' : 'carto')).toLowerCase();
+        const maxZoom = Number(options?.maxZoom || config.maxZoom || 19);
+
+        if (config.url) {
+            return {
+                url: config.url,
+                options: {
+                    attribution: config.attribution || providerAttribution[provider] || '',
+                    maxZoom,
+                    referrerPolicy: 'strict-origin-when-cross-origin',
+                },
+            };
+        }
+
+        if (provider === 'mapbox' && token) {
+            const mapboxStyle = style === 'light' ? 'light-v11' : 'streets-v12';
+            return {
+                url: `https://api.mapbox.com/styles/v1/mapbox/${mapboxStyle}/tiles/256/{z}/{x}/{y}@2x?access_token=${token}`,
+                options: {
+                    attribution: config.attribution || providerAttribution.mapbox,
+                    maxZoom,
+                },
+            };
+        }
+
+        if (provider === 'osm') {
+            return {
+                url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                options: {
+                    attribution: config.attribution || providerAttribution.osm,
+                    maxZoom,
+                    referrerPolicy: 'strict-origin-when-cross-origin',
+                },
+            };
+        }
+
+        return {
+            url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+            options: {
+                attribution: config.attribution || providerAttribution.carto,
+                maxZoom,
+            },
+        };
+    }
+
+    function createTileLayer(options) {
+        const definition = createTileDefinition(options);
+        return L.tileLayer(definition.url, Object.assign({}, definition.options, options?.leafletOptions || {}));
+    }
+
+    window.AuraMapTiles = {
+        createTileDefinition,
+        createTileLayer,
+    };
+})();

--- a/static/js/pages/route_manual.js
+++ b/static/js/pages/route_manual.js
@@ -418,9 +418,7 @@
                 if (!map) {
                     map = L.map('leaflet-map').setView([37.3886, -5.9823], 13);
 
-                    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                        attribution: '© OpenStreetMap contributors',
-                    }).addTo(map);
+                    window.AuraMapTiles.createTileLayer({ style: 'streets' }).addTo(map);
 
                     map.on('click', function (e) {
                         selectedCoords = e.latlng;

--- a/static/js/pages/route_map.js
+++ b/static/js/pages/route_map.js
@@ -1,12 +1,7 @@
 (function () {
     function crearMapaRuta({ elementId, center, token }) {
         const map = L.map(elementId).setView(center, 14);
-        const tileUrl = token
-            ? `https://api.mapbox.com/styles/v1/mapbox/streets-v12/tiles/256/{z}/{x}/{y}@2x?access_token=${token}`
-            : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-        const attribution = token ? '© Mapbox' : '© OpenStreetMap contributors';
-
-        L.tileLayer(tileUrl, { attribution }).addTo(map);
+        window.AuraMapTiles.createTileLayer({ token, style: 'streets' }).addTo(map);
         return map;
     }
 
@@ -42,9 +37,7 @@
             }
 
             map = L.map(mapId).setView(initialCoords, 13);
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© OpenStreetMap contributors',
-            }).addTo(map);
+            window.AuraMapTiles.createTileLayer({ style: 'streets' }).addTo(map);
 
             map.on('click', function (event) {
                 tempCoords = event.latlng;

--- a/templates/base.html
+++ b/templates/base.html
@@ -123,6 +123,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    {{ MAP_TILE_CONFIG|json_script:"aura-map-tiles-config" }}
+    <script src="{% static 'js/map_tiles.js' %}"></script>
     <script src="{% static 'js/ui_feedback.js' %}"></script>
 
     {% block extra_js %}{% endblock %}

--- a/tours/static/js/mapa_turista.js
+++ b/tours/static/js/mapa_turista.js
@@ -86,16 +86,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // Tiles minimalistas: fondo neutro claro donde la polilínea y los marcadores
     // destacan sin competir con texturas de satélite.
     const token = typeof mapboxToken !== 'undefined' ? mapboxToken : '';
-    const tileUrl = token
-        ? `https://api.mapbox.com/styles/v1/mapbox/light-v11/tiles/256/{z}/{x}/{y}@2x?access_token=${token}`
-        : 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
-
-    L.tileLayer(tileUrl, {
-        maxZoom:     19,
-        attribution: token
-            ? '© <a href="https://mapbox.com">Mapbox</a> © <a href="https://openstreetmap.org">OpenStreetMap</a>'
-            : '© <a href="https://carto.com">CARTO</a> © <a href="https://openstreetmap.org">OpenStreetMap</a>',
-    }).addTo(map);
+    window.AuraMapTiles.createTileLayer({ token, style: 'light' }).addTo(map);
 
     L.control.zoom({ position: 'bottomright' }).addTo(map);
 


### PR DESCRIPTION
Centraliza la configuración de tiles en Leaflet, corrige el 403 de OSM asegurando Referrer-Policy compatible y añade fallback de proveedor (Mapbox/Carto/OSM) configurable por entorno.